### PR TITLE
Remove duprecated method

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -22,7 +22,6 @@ if (__DEVELOPMENT__) {
 // https://github.com/halt-hammerzeit/webpack-isomorphic-tools
 var WebpackIsomorphicTools = require('webpack-isomorphic-tools');
 global.webpackIsomorphicTools = new WebpackIsomorphicTools(require('../webpack/webpack-isomorphic-tools'))
-  .development(__DEVELOPMENT__)
   .server(rootDir, function() {
     require('../src/server');
   });


### PR DESCRIPTION
Remove .development() in server.js because it is deperecated and show waning
It is no longer required if NODE_ENV is set as w/o production
https://github.com/halt-hammerzeit/webpack-isomorphic-tools#processenvnode_env